### PR TITLE
fix: insufficient funds for gas error when validating signature on UP contract

### DIFF
--- a/src/components/endpoints/Sign.vue
+++ b/src/components/endpoints/Sign.vue
@@ -54,11 +54,14 @@ const onSignatureValidation = async () => {
 
   try {
     const messageHash = getWeb3().eth.accounts.hashMessage(message.value);
-    magicValue.value =
-      window.erc725Account &&
-      ((await window.erc725Account.methods
+    if (window.erc725Account) {
+      // TODO: we should probably set the default gas price to undefined,
+      // but it is not yet clear why view functions error on L16 when gasPrice is passed
+      window.erc725Account.options.gasPrice = void 0;
+      magicValue.value = (await window.erc725Account.methods
         .isValidSignature(messageHash, signResponse.value.signature)
-        .call()) as string);
+        .call()) as string;
+    }
 
     if (magicValue.value === MAGICVALUE) {
       setNotification(`Signature validated successfully`, "info");

--- a/src/components/endpoints/__tests__/Sign.ts
+++ b/src/components/endpoints/__tests__/Sign.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_GAS_PRICE } from "@/helpers/config";
 import Sign from "../Sign.vue";
 import { render, fireEvent, screen } from "@testing-library/vue";
 import { setState } from "@/stores";
@@ -29,6 +30,9 @@ window.erc725Account = {
     isValidSignature: () => ({
       call: () => mockValidSignatureCall(),
     }),
+  },
+  options: {
+    gasPrice: DEFAULT_GAS_PRICE,
   },
 } as Contract;
 


### PR DESCRIPTION
### Description

This PR fixes an error that was occurring when you try to validate a message against a signature. The RPC node returns a `err: insufficient funds for gas * price + value: ...` error. After some investigation, it was discovered it's a recent behavior with L16 nodes (where passing an explicit `gasPrice` causes a call to a `view` function to fail). The fix here applies only for the special case of `signature validation` while we continue to investigate what has changed at the network level

Details: https://app.clickup.com/t/2jzquwd

<img width="301" alt="Message" src="https://user-images.githubusercontent.com/30433120/178975591-5aec0203-4960-40bf-93b1-09644748be99.png">
